### PR TITLE
Change contrast for small heading text

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -76,6 +76,7 @@ $foundation-palette: (
 $light-gray: #e6e6e6 !default;
 $medium-gray: #cacaca !default;
 $dark-gray: #8a8a8a !default;
+$darker-gray: #505a5f !default;
 $black: #0a0a0a !default;
 $white: #fefefe !default;
 $body-background: $white !default;
@@ -155,7 +156,7 @@ $header-styles: (
 ) !default;
 $header-text-rendering: optimizeLegibility !default;
 $small-font-size: 80% !default;
-$header-small-font-color: $medium-gray !default;
+$header-small-font-color: $darker-gray !default;
 $paragraph-lineheight: 1.6 !default;
 $paragraph-margin-bottom: 1rem !default;
 $paragraph-text-rendering: optimizeLegibility !default;


### PR DESCRIPTION
## Objectives

The default has a contrast of 1.61 which doesn't pass WCAG contrast guidelines.

I used a replacement gray which has a ratio of 6.95 on a white background that passes AA.

## Visual Changes

### Before

![image](https://user-images.githubusercontent.com/1650875/132498972-449fe71b-d205-4eb7-a4a9-1d1ad49140ee.png)

### After

![image](https://user-images.githubusercontent.com/1650875/132498989-64ad9c20-e77a-4ecd-8364-c7e4e8309855.png)