### PR TITLE
Display user information on users#show page for admins

### DIFF
--- a/app/views/custom/users/show.html.erb
+++ b/app/views/custom/users/show.html.erb
@@ -1,0 +1,80 @@
+<main>
+  <div class="activity row margin-top">
+    <div class="small-12 column">
+
+      <% if @user != current_user %>
+        <% if @user.email_on_direct_message? %>
+          <%= link_to t("users.show.send_private_message"),
+                      new_user_direct_message_path(@user),
+                      class: "button hollow float-right" %>
+        <% else %>
+          <div class="callout primary float-right">
+            <%= t("users.show.no_private_messages") %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <h2 class="inline-block">
+        <%= avatar_image(@user, seed: @user.id, size: 60) %>
+        <%= @user.name %>
+      </h2>
+
+      <% if current_administrator? %>
+        <p><%= t("users.show.user_information") %>:</p>
+        <table>
+          <thead>
+            <tr>
+              <th><%= t("users.show.field") %></th>
+              <th><%= t("users.show.value") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><%= t("users.show.email") %></td>
+              <td><%= @user.email %></td>
+            </tr>
+            <tr>
+              <td><%= t("users.show.document_number") %></td>
+              <td><%= @user.document_number %></td>
+            </tr>
+            <tr>
+              <td><%= t("users.show.phone_number") %></td>
+              <td><%= @user.phone_number %></td>
+            </tr>
+          </tbody>
+        </table>
+      <% end %>
+
+      <% if @user.public_activity || @authorized_current_user %>
+        <ul class="menu simple margin-top">
+          <% @valid_filters.each do |filter| %>
+            <% if @activity_counts[filter] > 0 %>
+              <% if @current_filter == filter %>
+                <li class="is-active">
+                  <h2><%= t("users.show.filters.#{filter}", count: @activity_counts[filter]) %></h2>
+                </li>
+              <% else %>
+                <li>
+                  <%= link_to t("users.show.filters.#{filter}", count: @activity_counts[filter]),
+                              current_path_with_query_params(filter: filter, page: 1) %>
+                </li>
+              <% end %>
+            <% end %>
+          <% end %>
+        </ul>
+
+        <% if @activity_counts.values.inject(&:+) == 0 %>
+          <div class="callout primary">
+            <%= t("users.show.no_activity") %>
+          </div>
+        <% end %>
+
+        <%= render "activity_page" %>
+      <% else %>
+        <div class="callout warning margin">
+          <%= t("users.show.private_activity") %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/config/locales/ro-RO/general.yml
+++ b/config/locales/ro-RO/general.yml
@@ -881,6 +881,12 @@ ro:
       private_activity: Acest utilizator a decis să își mențină activitatea privată.
       send_private_message: "Trimite mesaj privat"
       delete_alert: "Sigur doriți să ștergeți proiectul de investiții? Această acțiune nu poate fi anulată"
+      user_information: "Informații despre utilizator (vizibile doar pentru administratori)"
+      field: Câmp
+      value: Valoare
+      email: Email
+      document_number: CNP
+      phone_number: Număr de telefon
     proposals:
       retired: "Propunere retrasă"
       draft: Schiță

--- a/spec/system/verification/cnp_validation_spec.rb
+++ b/spec/system/verification/cnp_validation_spec.rb
@@ -20,4 +20,19 @@ describe "CNP" do
 
     expect(page).to have_content "Account verified"
   end
+
+  scenario "Admin can view a user's document number, email, and phone number" do
+    document_number = "1870113780091"
+    email = "foo@bar.com"
+    phone_number = "0745123456"
+    user = create(:user, document_number: document_number, email: email, phone_number: phone_number)
+    admin = create(:administrator)
+    login_as(admin.user)
+
+    visit user_path(user)
+
+    expect(page).to have_content document_number
+    expect(page).to have_content email
+    expect(page).to have_content phone_number
+  end
 end


### PR DESCRIPTION
## References

Related to #18.

## Objectives

Add a table with some basic user information and a test.

Remove the previous `<small>` tag in the header.

## Visual Changes

![image](https://user-images.githubusercontent.com/1650875/132499140-90387af5-06a4-402d-be68-62f5f6f692c1.png)

## Notes

```
$ bundle exec rspec spec/system/verification/cnp_validation_spec.rb

CNP
  User can verify with their CNP
  Admin can view a user's document number, email, and phone number

Finished in 12.18 seconds (files took 7.36 seconds to load)
2 examples, 0 failures

Randomized with seed 32892
```